### PR TITLE
Fix #66 - Missing icons in Justlight theme

### DIFF
--- a/ClassicLAFModule.php
+++ b/ClassicLAFModule.php
@@ -106,8 +106,7 @@ class ClassicLAFModule extends AbstractModule implements
       //we need a way to identify it regardless of its folder name;
       $theme = app(ModuleThemeInterface::class); 
       if ($theme instanceof ModuleCustomInterface) {
-        $justLightSupportUrl = 'https://github.com/justcarmen/webtrees-theme-justlight/issues';
-        if ($theme->customModuleSupportUrl() === $justLightSupportUrl) {
+        if ($theme->name() === '_jc-theme-justlight_') {
           $defaultLayout = '::layouts/defaultJustLight';
         }
       }  


### PR DESCRIPTION
Make default view for Justlight theme depend on internal name in stead of support url

See: https://github.com/JustCarmen/webtrees-theme-justlight/issues/102

I've changed the support url for this theme. Since this change the footer scripts are not loaded correctly. I think it is better use the internal name in stead of the support url.